### PR TITLE
Transaction ID not saved correctly

### DIFF
--- a/CRM/Core/Payment/Beanstream.php
+++ b/CRM/Core/Payment/Beanstream.php
@@ -91,7 +91,7 @@ class CRM_Core_Payment_Beanstream extends CRM_Core_Payment {
       return self::error($message);
     }
     else { // transaction was approved!
-      $params['trxn_id'] = $result['authCode'] . ':' . time();
+      $params['trxn_id'] = $result['trnId'] . ':' . time();
       $params['gross_amount'] = $params['amount'];
       if ($isRecur) { 
         // TODO: save the profile information in beanstream, needs a separate POST


### PR DESCRIPTION
Instead of the transaction ID, the extension was saving beanstream's "Approval Code" which is not useful when searching for and comparing transactions.
Unless there was another purpose for the code to be saved.
