### PR TITLE
Processing failure when no order number is passed

### DIFF
--- a/CRM/Beanstream/POST.php
+++ b/CRM/Beanstream/POST.php
@@ -52,6 +52,12 @@ class Beanstream_POST {
       // log: ip, invoiceNum, , cc, total, date
       // print_r($logged_request); die();
       $ip = (function_exists('ip_address') ? ip_address() : $_SERVER['REMOTE_ADDR']);
+
+      if ($logged_request['trnOrderNumber'] == null) {
+        // Need to set this as it's null in some cases (webform_civicrm)
+        $logged_request['trnOrderNumber'] = '';
+      }
+
       $query_params = array(
         1 => array($logged_request['trnOrderNumber'], 'String'),
         2 => array($ip, 'String'),


### PR DESCRIPTION
The webform_civicrm module supports contribution pages in webform but doesn't pass an order number to the transaction engine. civicrm_beanstream_request_log requires an invoice number even though beanstream technically doesn't.

Of course one could argue that the issue is with webform_civicrm instead so there is that.

This just adds an empty string rather than a null.
Maybe a better fix would be to change the db field definition but this may create other issues elsewhere.
